### PR TITLE
Fix crash at runtime caused by MixinBlockEnergyCube

### DIFF
--- a/src/main/java/com/jerry/mekanism_extras/mixin/MixinBlockEnergyCube.java
+++ b/src/main/java/com/jerry/mekanism_extras/mixin/MixinBlockEnergyCube.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-@Mixin(value = BlockEnergyCube.class, remap = false)
+@Mixin(value = BlockEnergyCube.class)
 public class MixinBlockEnergyCube {
     @ModifyArg(method = "getShape", at = @At(value = "INVOKE", target = "Lmekanism/common/util/WorldUtils;getTileEntity(Ljava/lang/Class;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Z)Lnet/minecraft/world/level/block/entity/BlockEntity;"), index = 3)
     private boolean preventWarnLog(boolean original) {

--- a/src/main/resources/mekanism_extras.mixins.json
+++ b/src/main/resources/mekanism_extras.mixins.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "com.jerry.mekanism_extras.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "Mekanism_Extras.refmap.json",
+  "refmap": "mekanism_extras.refmap.json",
   "mixins": [
     "MixinBinInventorySlot",
     "MixinBlockEnergyCube",


### PR DESCRIPTION
Fixes a crash at runtime (outside of the dev environment).  
The issue was caused by changes introduced in #40.  
Sorry for not testing outside the development environment earlier.

Crash log: https://mclo.gs/9gayxe2
