### PR TITLE
Resolving competition with MekanismEmpowered

### DIFF
--- a/src/main/java/com/jerry/mekanism_extras/common/tile/factory/TileEntityAdvancedFactory.java
+++ b/src/main/java/com/jerry/mekanism_extras/common/tile/factory/TileEntityAdvancedFactory.java
@@ -447,7 +447,7 @@ public abstract class TileEntityAdvancedFactory<RECIPE extends MekanismRecipe> e
         }
     }
 
-    private void updateMaxEnergy() {
+    public void updateMaxEnergy() {
         for (IEnergyContainer energyContainer : getEnergyContainers(null)) {
             if (energyContainer instanceof MachineEnergyContainer<?> machineEnergy) {
                 if (this.supportsUpgrade(Upgrade.ENERGY) || this.supportsUpgrade(ExtraUpgrade.CREATIVE)) {

--- a/src/main/java/com/jerry/mekanism_extras/mixin/MixinMachineEnergyContainer.java
+++ b/src/main/java/com/jerry/mekanism_extras/mixin/MixinMachineEnergyContainer.java
@@ -3,17 +3,14 @@ package com.jerry.mekanism_extras.mixin;
 import com.jerry.mekanism_extras.api.ExtraUpgrade;
 import mekanism.api.AutomationType;
 import mekanism.api.IContentsListener;
-import mekanism.api.Upgrade;
 import mekanism.api.math.FloatingLong;
 import mekanism.common.capabilities.energy.BasicEnergyContainer;
 import mekanism.common.capabilities.energy.MachineEnergyContainer;
 import mekanism.common.tile.base.TileEntityMekanism;
-import mekanism.common.util.MekanismUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -44,21 +41,6 @@ public abstract class MixinMachineEnergyContainer<TILE extends TileEntityMekanis
     public void mixinGetEnergyPerTick(CallbackInfoReturnable<FloatingLong> cir) {
         if (tile.supportsUpgrade(ExtraUpgrade.CREATIVE)) {
             cir.setReturnValue(tile.getComponent().isUpgradeInstalled(ExtraUpgrade.CREATIVE) ? FloatingLong.ZERO : currentEnergyPerTick);
-        }
-    }
-
-    /**
-     * @author LostMyself
-     * @reason 兼容创造升级带来的能量变化，不过这会使得兼容性不太高。
-     */
-    @Overwrite
-    public void updateMaxEnergy() {
-        if (tile.supportsUpgrade(Upgrade.ENERGY) || tile.supportsUpgrade(ExtraUpgrade.CREATIVE)) {
-            if (tile.getComponent().isUpgradeInstalled(ExtraUpgrade.CREATIVE)) {
-                setMaxEnergy(FloatingLong.MAX_VALUE);
-            } else {
-                setMaxEnergy(MekanismUtils.getMaxEnergy(tile, getBaseMaxEnergy()));
-            }
         }
     }
 }


### PR DESCRIPTION
In order to avoid competition with MekanismEmpowered, it was necessary to make changes to Mekanism Extra.
Since it could not be resolved with mixin's `@Inject`, we added the `updateMaxEnergy()` method to `TileEntityAdvancedFactory` to resolve the issue.
Once merged, we plan to submit issues to MekanismEmpowered and ask them to make changes to mods.toml.