### PR TITLE
Fixs：修复无等离子端口时强制锁定98，可能修复服务器成型bug

### DIFF
--- a/src/main/java/com/jerry/mekanism_extras/mixin/MixinFusionReactorMultiblockData.java
+++ b/src/main/java/com/jerry/mekanism_extras/mixin/MixinFusionReactorMultiblockData.java
@@ -52,10 +52,10 @@ public abstract class MixinFusionReactorMultiblockData extends MultiblockData {
     @Inject(method = "tick", at = @At("HEAD"))
     private void meke$modifyFuelConsumption(Level world, CallbackInfoReturnable<Boolean> cir) {
         if (meke$outputPlasma) {
-	        if (injectionRate != MAX_INJECTION) {
-		        markDirty();
-	        }
-	        injectionRate = MAX_INJECTION;
+            if (injectionRate != MAX_INJECTION) {
+                markDirty();
+            }
+            injectionRate = MAX_INJECTION;
         }
     }
 


### PR DESCRIPTION
## What / 目的
_修复无等离子端口时强制锁定98，可能修复服务器成型bug_

## Implementation Details / 实现细节
_修改判断逻辑无等离子端口时不进行赋值操作_

## Outcome / 结果
_反应堆数值正常_

## Additional Information / 附加信息
_无_

## Potential Compatibility Issues / 潜在兼容性问题
_无_