### PR TITLE
fix mekmm 1.4 compatibility

### DIFF
--- a/src/main/java/com/jerry/mekextras/client/recipe_viewer/jei/ExtraMMCatalystRegistryHelper.java
+++ b/src/main/java/com/jerry/mekextras/client/recipe_viewer/jei/ExtraMMCatalystRegistryHelper.java
@@ -1,5 +1,6 @@
 package com.jerry.mekextras.client.recipe_viewer.jei;
 
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.registries.ExtraMoreMachineBlocks;
 import com.jerry.mekextras.common.tier.ExtraFactoryTier;
 import com.jerry.mekextras.common.util.ExtraEnumUtils;
@@ -33,7 +34,7 @@ public class ExtraMMCatalystRegistryHelper {
             Item item = workstation.asItem();
             if (item instanceof BlockItem blockItem) {
                 MoreMachineAttributeFactoryType factoryType = Attribute.get(blockItem.getBlock(), MoreMachineAttributeFactoryType.class);
-                if (factoryType != null) {
+                if (factoryType != null && MoreMachineIntegrationCompat.isFactoryTypeSupported(factoryType.getMoreMachineFactoryType())) {
                     for (ExtraFactoryTier tier : ExtraEnumUtils.EXTRA_FACTORY_TIERS) {
                         registry.addRecipeCatalyst(ExtraMoreMachineBlocks.getExtraMoreMachineFactory(tier, factoryType.getMoreMachineFactoryType()), recipeType);
                     }

--- a/src/main/java/com/jerry/mekextras/common/integration/mekmm/MoreMachineIntegrationCompat.java
+++ b/src/main/java/com/jerry/mekextras/common/integration/mekmm/MoreMachineIntegrationCompat.java
@@ -1,0 +1,35 @@
+package com.jerry.mekextras.common.integration.mekmm;
+
+import com.jerry.mekmm.common.content.blocktype.MoreMachineFactoryType;
+
+/**
+ * Compatibility boundary for Mekanism: MoreMachine integration.
+ *
+ * Mekanism Extras only provides extra-tier factories for the factory types it was
+ * explicitly implemented for. New MoreMachine enum values must not be treated as
+ * supported automatically just because MoreMachineFactoryType.values() contains them.
+ */
+public final class MoreMachineIntegrationCompat {
+
+    public static final MoreMachineFactoryType[] SUPPORTED_FACTORY_TYPES = {
+            MoreMachineFactoryType.RECYCLING,
+            MoreMachineFactoryType.PLANTING_STATION,
+            MoreMachineFactoryType.CNC_STAMPING,
+            MoreMachineFactoryType.CNC_LATHING,
+            MoreMachineFactoryType.CNC_ROLLING_MILL,
+            MoreMachineFactoryType.REPLICATING
+    };
+
+    private MoreMachineIntegrationCompat() {}
+
+    public static boolean isFactoryTypeSupported(MoreMachineFactoryType type) {
+        return switch (type) {
+            case RECYCLING, PLANTING_STATION, CNC_STAMPING, CNC_LATHING, CNC_ROLLING_MILL, REPLICATING -> true;
+            default -> false;
+        };
+    }
+
+    public static IllegalArgumentException unsupportedFactoryType(MoreMachineFactoryType type) {
+        return new IllegalArgumentException("Unsupported Mekanism: MoreMachine factory type: " + type);
+    }
+}

--- a/src/main/java/com/jerry/mekextras/common/integration/mekmm/content/blocktype/ExtraMoreMachineFactory.java
+++ b/src/main/java/com/jerry/mekextras/common/integration/mekmm/content/blocktype/ExtraMoreMachineFactory.java
@@ -4,6 +4,7 @@ import com.jerry.mekextras.common.block.attribute.ExtraAttributeTier;
 import com.jerry.mekextras.common.block.attribute.ExtraAttributeUpgradeable;
 import com.jerry.mekextras.common.content.blocktype.ExtraMachine.ExtraFactoryMachine;
 import com.jerry.mekextras.common.content.blocktype.ExtraMachine.ExtraMachineBuilder;
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.registries.ExtraMoreMachineBlockTypes;
 import com.jerry.mekextras.common.integration.mekmm.registries.ExtraMoreMachineBlocks;
 import com.jerry.mekextras.common.integration.mekmm.registries.ExtraMoreMachineContainerTypes;
@@ -68,6 +69,7 @@ public class ExtraMoreMachineFactory<TILE extends TileEntityExtraMoreMachineFact
             builder.with(switch (type) {
                 case RECYCLING, CNC_STAMPING, CNC_LATHING, CNC_ROLLING_MILL -> AttributeSideConfig.ELECTRIC_MACHINE;
                 case PLANTING_STATION, REPLICATING -> AttributeSideConfig.ADVANCED_ELECTRIC_MACHINE;
+                default -> throw MoreMachineIntegrationCompat.unsupportedFactoryType(type);
             });
             // 如果有Bounding属性就添加，但或许会有更复杂的形状
             if (getBaseMachine(type).has(AttributeHasBounding.class)) {
@@ -97,6 +99,7 @@ public class ExtraMoreMachineFactory<TILE extends TileEntityExtraMoreMachineFact
                 case CNC_LATHING -> ExtraMoreMachineBlockTypes.CNC_LATHE;
                 case CNC_ROLLING_MILL -> ExtraMoreMachineBlockTypes.CNC_ROLLING_MILL;
                 case REPLICATING -> ExtraMoreMachineBlockTypes.REPLICATOR;
+                default -> throw MoreMachineIntegrationCompat.unsupportedFactoryType(type);
             };
         }
     }

--- a/src/main/java/com/jerry/mekextras/common/integration/mekmm/item/block/machine/ItemBlockExtraMoreMachineFactory.java
+++ b/src/main/java/com/jerry/mekextras/common/integration/mekmm/item/block/machine/ItemBlockExtraMoreMachineFactory.java
@@ -1,6 +1,7 @@
 package com.jerry.mekextras.common.integration.mekmm.item.block.machine;
 
 import com.jerry.mekextras.common.block.attribute.ExtraAttribute;
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.block.prefab.ExtraMoreMachineBlockFactoryMachine.BlockExtraMoreMachineFactory;
 import com.jerry.mekextras.common.item.block.ItemBlockExtraTooltip;
 import com.jerry.mekextras.common.tier.ExtraFactoryTier;
@@ -26,10 +27,12 @@ import java.util.List;
 public class ItemBlockExtraMoreMachineFactory extends ItemBlockExtraTooltip<BlockTile<?, ?>> {
 
     private static AttachedSideConfig getSideConfig(BlockExtraMoreMachineFactory<?> block) {
-        return switch (Attribute.getOrThrow(block.builtInRegistryHolder(), MoreMachineAttributeFactoryType.class).getMoreMachineFactoryType()) {
+        var type = Attribute.getOrThrow(block.builtInRegistryHolder(), MoreMachineAttributeFactoryType.class).getMoreMachineFactoryType();
+        return switch (type) {
             case CNC_STAMPING -> AttachedSideConfig.EXTRA_MACHINE;
             case RECYCLING, CNC_LATHING, CNC_ROLLING_MILL -> AttachedSideConfig.ELECTRIC_MACHINE;
             case PLANTING_STATION, REPLICATING -> AttachedSideConfig.ADVANCED_MACHINE_INPUT_ONLY;
+            default -> throw MoreMachineIntegrationCompat.unsupportedFactoryType(type);
         };
     }
 

--- a/src/main/java/com/jerry/mekextras/common/integration/mekmm/registries/ExtraMoreMachineBlockTypes.java
+++ b/src/main/java/com/jerry/mekextras/common/integration/mekmm/registries/ExtraMoreMachineBlockTypes.java
@@ -3,6 +3,7 @@ package com.jerry.mekextras.common.integration.mekmm.registries;
 import com.jerry.mekextras.common.block.attribute.ExtraAttributeUpgradeSupport;
 import com.jerry.mekextras.common.content.blocktype.ExtraMachine.ExtraFactoryMachine;
 import com.jerry.mekextras.common.content.blocktype.ExtraMachine.ExtraMachineBuilder;
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.content.blocktype.ExtraMoreMachineFactory;
 import com.jerry.mekextras.common.integration.mekmm.content.blocktype.ExtraMoreMachineFactory.ExtraMoreMachineFactoryBuilder;
 import com.jerry.mekextras.common.tier.ExtraFactoryTier;
@@ -19,7 +20,6 @@ import com.jerry.mekmm.common.content.blocktype.MoreMachineFactoryType;
 import com.jerry.mekmm.common.registries.MoreMachineContainerTypes;
 import com.jerry.mekmm.common.registries.MoreMachineTileEntityTypes;
 import com.jerry.mekmm.common.tile.machine.*;
-import com.jerry.mekmm.common.util.MoreMachineEnumUtils;
 
 public class ExtraMoreMachineBlockTypes {
 
@@ -84,7 +84,7 @@ public class ExtraMoreMachineBlockTypes {
 
     static {
         for (ExtraFactoryTier tier : ExtraEnumUtils.EXTRA_FACTORY_TIERS) {
-            for (MoreMachineFactoryType type : MoreMachineEnumUtils.MM_FACTORY_TYPES) {
+            for (MoreMachineFactoryType type : MoreMachineIntegrationCompat.SUPPORTED_FACTORY_TYPES) {
                 MM_FACTORIES.put(tier, type, ExtraMoreMachineFactoryBuilder.createMoreMachineFactory(() -> ExtraMoreMachineTileEntityTypes.getExtraMoreMachineFactoryTile(tier, type), type, tier).build());
             }
         }

--- a/src/main/java/com/jerry/mekextras/common/integration/mekmm/registries/ExtraMoreMachineBlocks.java
+++ b/src/main/java/com/jerry/mekextras/common/integration/mekmm/registries/ExtraMoreMachineBlocks.java
@@ -3,6 +3,7 @@ package com.jerry.mekextras.common.integration.mekmm.registries;
 import com.jerry.mekextras.MekanismExtras;
 import com.jerry.mekextras.api.tier.IAdvancedTier;
 import com.jerry.mekextras.common.block.attribute.ExtraAttributeTier;
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.block.prefab.ExtraMoreMachineBlockFactoryMachine.BlockExtraMoreMachineFactory;
 import com.jerry.mekextras.common.integration.mekmm.content.blocktype.ExtraMoreMachineFactory;
 import com.jerry.mekextras.common.integration.mekmm.item.block.machine.ItemBlockExtraMoreMachineFactory;
@@ -30,7 +31,6 @@ import com.jerry.mekmm.common.recipe.MoreMachineRecipeType;
 import com.jerry.mekmm.common.tile.factory.TileEntityReplicatingFactory;
 import com.jerry.mekmm.common.tile.machine.TileEntityPlantingStation;
 import com.jerry.mekmm.common.tile.machine.TileEntityReplicator;
-import com.jerry.mekmm.common.util.MoreMachineEnumUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -49,7 +49,7 @@ public class ExtraMoreMachineBlocks {
     static {
         // factories
         for (ExtraFactoryTier tier : ExtraEnumUtils.EXTRA_FACTORY_TIERS) {
-            for (MoreMachineFactoryType type : MoreMachineEnumUtils.MM_FACTORY_TYPES) {
+            for (MoreMachineFactoryType type : MoreMachineIntegrationCompat.SUPPORTED_FACTORY_TYPES) {
                 MM_FACTORIES.put(tier, type, registerMoreMachineFactory(ExtraMoreMachineBlockTypes.getExtraMoreMachineFactory(tier, type)));
             }
         }
@@ -67,6 +67,7 @@ public class ExtraMoreMachineBlocks {
                 case CNC_LATHING -> s -> MoreMachineRecipeType.LATHING.getInputCache().containsInput(null, s);
                 case CNC_ROLLING_MILL -> s -> MoreMachineRecipeType.ROLLING_MILL.getInputCache().containsInput(null, s);
                 case REPLICATING -> TileEntityReplicator::isValidItemInput;
+                default -> throw MoreMachineIntegrationCompat.unsupportedFactoryType(type.getMoreMachineFactoryType());
             };
             switch (type.getMoreMachineFactoryType()) {
                 case CNC_STAMPING -> holder.addAttachmentOnlyContainers(ContainerType.ITEM, () -> ItemSlotsBuilder.builder()

--- a/src/main/java/com/jerry/mekextras/mixin/integration/mekmm/MixinMoreMachineFactory.java
+++ b/src/main/java/com/jerry/mekextras/mixin/integration/mekmm/MixinMoreMachineFactory.java
@@ -1,6 +1,7 @@
 package com.jerry.mekextras.mixin.integration.mekmm;
 
 import com.jerry.mekextras.common.block.attribute.ExtraAttributeUpgradeable;
+import com.jerry.mekextras.common.integration.mekmm.MoreMachineIntegrationCompat;
 import com.jerry.mekextras.common.integration.mekmm.registries.ExtraMoreMachineBlocks;
 import com.jerry.mekextras.common.tier.ExtraFactoryTier;
 
@@ -26,7 +27,7 @@ public abstract class MixinMoreMachineFactory extends BlockType {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void injectFactoryUltimateToAbsolute(Supplier<?> tileEntityRegistrar, Supplier<?> containerRegistrar, MoreMachineFactoryMachine<?> origMachine, FactoryTier tier, CallbackInfo ci) {
-        if (tier == FactoryTier.ULTIMATE) {
+        if (tier == FactoryTier.ULTIMATE && MoreMachineIntegrationCompat.isFactoryTypeSupported(origMachine.getMoreMachineFactoryType())) {
             add(new ExtraAttributeUpgradeable(() -> ExtraMoreMachineBlocks.getExtraMoreMachineFactory(ExtraFactoryTier.ABSOLUTE, origMachine.getMoreMachineFactoryType())));
         }
     }


### PR DESCRIPTION
## What / 目的

Fix compatibility with Mekanism: MoreMachine 1.4.0.

MekMM 1.4.0 added the new `PRESSING` factory type. Mekanism Extras assumed every value in `MoreMachineFactoryType` was supported and attempted to create an Extras factory for it, causing a `MatchException` during mod construction.

## Implementation Details / 实现细节

Mekanism Extras now only iterates the MekMM factory types it actually supports instead of using every value exposed by MekMM.

Unsupported factory types are also skipped in the related upgrade and JEI integration paths.

No support for the new Pressing factory was added. It remains fully handled by MekMM.

## Outcome / 结果

Prevents Mekanism Extras from crashing when used with MekMM 1.4.0.

Existing supported MekMM factory types continue to work as before, while unknown or unsupported factory types are ignored.

## Potential Compatibility Issues / 潜在兼容性问题

No existing machines, recipes or factory behavior are changed.

The only compatibility change is that MekMM factory types not explicitly supported by Mekanism Extras are no longer automatically treated as supported.